### PR TITLE
Add ResponseIter.__next__

### DIFF
--- a/gerrit/__init__.py
+++ b/gerrit/__init__.py
@@ -43,6 +43,9 @@ class ResponseIter(object):
         self.close()
         raise StopIteration()
 
+    def __next__(self):
+        return self.next()
+
     def close(self):
         self._stdout.close()
         self._stderr.close()


### PR DESCRIPTION
According to https://www.python.org/dev/peps/pep-3114/ , iterators'
'next' function should be named '__next__'. This change ensures both
exist.

Otherwise, the following error occurs in python 3.6:
`TypeError: iter() returned non-iterator of type 'ResponseIter'`